### PR TITLE
Fix tests failures, improve Python 3.10 compatibility, release support

### DIFF
--- a/pypi.sh
+++ b/pypi.sh
@@ -11,9 +11,8 @@ EOF
 echo "tempdir: ${wdir}"
 echo "version: ${version}"
 cd $wdir
-wget https://github.com/al-niessner/pyxb/archive/${version}.tar.gz
-tar  --strip-components=1 -xzf ${version}.tar.gz
-python3 setup.py sdist bdist_wheel
+tar  --strip-components=1 -xzf $bdir/RELEASES/PyXB-CTC-${version}.tar.gz
+python3 setup.py sdist
 twine check dist/*
 twine upload --verbose dist/*
 cd ${bdir}

--- a/pyxb/binding/basis.py
+++ b/pyxb/binding/basis.py
@@ -17,7 +17,7 @@
 inherit, and that describe the content models of those schema."""
 
 import logging
-import collections
+import collections.abc
 import xml.dom
 import pyxb
 from pyxb.utils import domutils, utility, six
@@ -1163,7 +1163,7 @@ class simpleTypeDefinition (_TypeBinding_mixin, utility._DeconflictSymbols_mixin
             raise pyxb.SimpleTypeValueError(cls, value)
         value_class = cls
         if issubclass(cls, STD_list):
-            if not isinstance(value, collections.Iterable):
+            if not isinstance(value, collections.abc.Iterable):
                 raise pyxb.SimpleTypeValueError(cls, value)
             for v in value:
                 if not cls._ItemType._IsValidValue(v):
@@ -1363,7 +1363,7 @@ class STD_list (simpleTypeDefinition, six.list_type):
             if isinstance(arg1, six.string_types):
                 args = (arg1.split(),) + args[1:]
                 arg1 = args[0]
-            if isinstance(arg1, collections.Iterable):
+            if isinstance(arg1, collections.abc.Iterable):
                 new_arg1 = [ cls._ValidatedItem(_v, kw) for _v in arg1 ]
                 args = (new_arg1,) + args[1:]
         super_fn = getattr(super(STD_list, cls), '_ConvertArguments_vx', lambda *a,**kw: args)
@@ -1646,7 +1646,7 @@ class element (utility._DeconflictSymbols_mixin, _DynamicCreate_mixin):
             return self.__defaultValue
         is_plural = kw.pop('is_plural', False)
         if is_plural:
-            if not isinstance(value, collections.Iterable):
+            if not isinstance(value, collections.abc.Iterable):
                 raise pyxb.SimplePluralValueError(self.typeDefinition(), value)
             return [ self.compatibleValue(_v) for _v in value ]
         compValue = self.typeDefinition()._CompatibleValue(value, **kw);

--- a/pyxb/utils/saxdom.py
+++ b/pyxb/utils/saxdom.py
@@ -242,6 +242,9 @@ class NamedNodeMap (object):
     def item (self, index):
         return self.__members[index]
 
+    def __iter__(self):
+        return iter(self.item(i) for i in range(self.length))
+
     def _addItem (self, attr):
         assert pyxb.namespace.NamespaceContext.GetNodeContext(attr) is not None
         self.__members.append(attr)

--- a/pyxb/utils/testutils.py
+++ b/pyxb/utils/testutils.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain a
+# copy of the License at:
+#
+#            http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+"""Functions used for testing"""
+
+from unittest import TestCase
+
+from .domutils import StringToDOM
+
+
+class XmlTestCase(TestCase):
+    def __init__(self, *args, **kw):
+        super().__init__(*args, **kw)
+        self.addTypeEqualityFunc(bytes, 'assertBytesEqual')
+
+    def assertBytesEqual(self, first, second, msg=None):
+        if first == second:
+            return
+        if first.startswith(b"<") and second.startswith(b"<"):
+            # assume XML documents
+            try:
+                fd = StringToDOM(first)
+                sd = StringToDOM(second)
+            except Exception: pass
+            else:
+                self.assertDOMEqual(fd, sd, msg)
+                return
+        self._baseAssertEqual(first, second, msg)
+
+    def assertDOMEqual(self, d1, d2, msg=None):
+        """assert DOMs *d1* and *d2* are equivalent."""
+
+        def fail(txt):
+            raise self.failureException(msg or txt)
+
+        def node_name(n):
+            return (f"{{{n.namespaceURI}}}" if n.namespaceURI else "") + f"{n.localName}"
+
+        def eq_element(e1, e2, path):
+            """assert elements *e1* and *e2* at *path* are equivalent."""
+            t1 = node_name(e1)
+            t2 = node_name(e2)
+            if t1 != t2:
+                fail(f"different elements {t1}/{t2} at {path}")
+            path += "/" + t1
+            a1 = {node_name(a): a.value for a in e1.attributes}
+            a2 = {node_name(a): a.value for a in e2.attributes}
+            if a1 != a2:
+                fail(f"different attributes {a1}/{a2} at {path}")
+            c1 = e1.childNodes
+            c2 = e2.childNodes
+            if len(c1) != len(c2):
+                fail(f"different child numbers {len(c1)}/{len(c2)} at {path}")
+            for i in range(len(c1)):
+                n1 = c1[i]; n2 = c2[i]
+                if n1.nodeType != n2.nodeType:
+                    fail(f"different type for child {i} at {path}")
+                disp[n1.nodeType](n1, n2, path + f"[{i}]")
+
+        def eq_value(e1, e2, path):
+            if e1.value != e2.value:
+                fail(f"different value `{e1.value}`/`{e2.value}` at {path}")
+
+        disp = {1: eq_element,
+                3: eq_value,
+                # maybe more to come
+                }
+
+        eq_element(d1.documentElement, d2.documentElement, "")

--- a/scripts/makedist
+++ b/scripts/makedist
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 # Make distribution for branch $1 or `next` and store it in RELEASES
 
 # Assumption is that the development git repository is in PYXB_ROOT or ".",
@@ -94,7 +94,7 @@ stamp Unpacking final distribution over repo area to show differences
 cd ${WORK_DIR}/pyxb
 rm -rf *
 tar x --strip-components=1 -zf ${PACKAGED_TGZ}
-git stat
+git status
 
 stamp Unpacking final distribution file
 cd ${WORK_DIR}

--- a/scripts/makedist
+++ b/scripts/makedist
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Make distribution for branch $1 or `next` and store it in RELEASES
+
+# Assumption is that the development git repository is in PYXB_ROOT or ".",
+# and that there is a RELEASES subdirectory of this holding the
+# releases.
+
+fail () {
+  echo 1>&2 "${test_name} FAILED: ${@}"
+  exit 1
+}
+
+stamp () { 
+  echo "===>" $* "<===" `date`
+}
+
+set -e
+
+# Set this so if this script is redirected to a file, the output
+# will still be generated as utf-8 as it would be to a terminal.
+export PYTHONIOENCODING='utf-8'
+
+
+PYXB_REAL_ROOT=$(cd ${PYXB_ROOT:-.} && pwd)
+
+if [ ! -d ${PYXB_REAL_ROOT}/pyxb ]
+    then fail PYXB does not point to the development git repository
+fi
+if [ ! -d ${PYXB_REAL_ROOT}/RELEASES ]
+    then fail Missing RELEASES directory
+fi
+
+BRANCH=${1:-next}
+
+# Real root might have a cached copy of the schemas, in which case
+# we should grab them from there instead of taxing the W3C's servers
+# with repeated requests
+export PYXB_SCHEMA_REPO=${PYXB_REAL_ROOT}
+
+exec | tee makedist.log 2>&1
+
+WORK_DIR=$(mktemp -d -t pyxbdist.XXXXXXX)
+stamp Cloning into ${WORK_DIR}
+cd ${WORK_DIR}
+git clone -b ${BRANCH} ${PYXB_REAL_ROOT} pyxb
+cd pyxb
+
+export PYXB_ROOT=${WORK_DIR}/pyxb
+export PYTHONPATH=${PYXB_ROOT}
+
+# Update the version numbers in the source
+version=$(grep ^version setup.py | cut -d= -f2 | sed -e "s@'@@g")
+
+stamp Updating version information to ${version}
+./setup.py update_version
+git status || fail Unsaved deltas present
+
+stamp Packaging basic source distribution
+./setup.py sdist
+ver=`ls -rt dist | tail -1 | sed -e 's@^PyXB-\(.*\).tar.gz$@\1@'`
+DISTROOT=PyXB-${ver}
+EXPORTED_TGZ=${WORK_DIR}/pyxb/dist/${DISTROOT}.tar.gz
+cd ${WORK_DIR}
+
+stamp Unpacking source distribution into ${DISTROOT}
+rm -rf ${DISTROOT}
+tar xzf ${EXPORTED_TGZ}
+cd ${DISTROOT} || fail Unable to enter unpacked basic distribution
+
+export PYXB_ROOT=${WORK_DIR}/${DISTROOT}
+export PYTHONPATH=${PYXB_ROOT}
+
+# Build the documentation
+stamp Building documentation
+cd doc
+rm -rf html
+make html || fail Unable to build documentation
+cd ..
+
+# Generate the bundles
+stamp Generating bundles
+maintainer/genbundles
+
+# Rebuild the derived files and save the packaged file
+stamp Re-packaging sources with generated files included
+./setup.py sdist
+PACKAGED_TGZ=${WORK_DIR}/${DISTROOT}.tar.gz
+cp -p dist/${DISTROOT}.tar.gz ${PACKAGED_TGZ}
+cd ..
+
+# Check out the original, remove all the files, unpack the
+# distribution over it, and display the differences:
+stamp Unpacking final distribution over repo area to show differences
+cd ${WORK_DIR}/pyxb
+rm -rf *
+tar x --strip-components=1 -zf ${PACKAGED_TGZ}
+git stat
+
+stamp Unpacking final distribution file
+cd ${WORK_DIR}
+rm -rf ${DISTROOT}-old
+mv ${DISTROOT} ${DISTROOT}-old
+tar xzf ${PACKAGED_TGZ}
+#PACKAGED_ZIP=${WORK_DIR}/${DISTROOT}.zip
+#zip -r ${PACKAGED_ZIP} ${DISTROOT}
+cd ${DISTROOT} || fail Unable to cd into unpacked distribution
+
+# Test it
+stamp Testing final distribution file
+PATH=${PYXB_ROOT}/scripts:${PATH} ./setup.py test || fail Packaged distribution failed tests
+
+# And, if it passed, save it
+cp -pf ${PACKAGED_TGZ} ${PACKAGED_ZIP} ${PYXB_REAL_ROOT}/RELEASES/

--- a/scripts/makedist
+++ b/scripts/makedist
@@ -1,9 +1,14 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # Make distribution for branch $1 or `next` and store it in RELEASES
 
 # Assumption is that the development git repository is in PYXB_ROOT or ".",
 # and that there is a RELEASES subdirectory of this holding the
 # releases.
+
+if [ -z "$PYXB_REDIRECT_" ] ; then
+   PYXB_REDIRECT_=1  "$0" "$@" |& tee makedist.log
+   exit $?
+fi
 
 fail () {
   echo 1>&2 "${test_name} FAILED: ${@}"
@@ -36,8 +41,6 @@ BRANCH=${1:-next}
 # we should grab them from there instead of taxing the W3C's servers
 # with repeated requests
 export PYXB_SCHEMA_REPO=${PYXB_REAL_ROOT}
-
-exec | tee makedist.log 2>&1
 
 WORK_DIR=$(mktemp -d -t pyxbdist.XXXXXXX)
 stamp Cloning into ${WORK_DIR}

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 import sys
 
 # The current version of the system.  Format is #.#.#[-DEV].
-version = '1.3.0'
+version = '1.3.1'
 
 # Require Python 3.10 or higher
 if (sys.version_info[:2] < (3, 10)):

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ if (sys.version_info[:2] < (3, 10)):
 (You have %s.)''' % (sys.version,))
 
 import os
+import os.path
 import stat
 import re
 import datetime
@@ -51,7 +52,8 @@ class update_version (Command):
             text = open('%s.in' % (f,)).read()
             for (k, v) in self.substitutions.items():
                 text = text.replace('@%s@' % (k,), v)
-            os.chmod(f, os.stat(f)[stat.ST_MODE] | stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH)
+            if os.path.exists(f):
+                os.chmod(f, os.stat(f)[stat.ST_MODE] | stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH)
             open(f,'w').write(text)
             os.chmod(f, os.stat(f)[stat.ST_MODE] & ~(stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH))
 

--- a/tests/datatypes/test-dateTime.py
+++ b/tests/datatypes/test-dateTime.py
@@ -84,6 +84,22 @@ class Test_dateTime (unittest.TestCase):
         print(str(dt))
         print(dt.aslocal())
 
+    def testTimezoneAjustment(self):
+        preserve = pyxb.PreserveInputTimeZone()
+        try:
+            pyxb.PreserveInputTimeZone(False)
+            dt = xsd.dateTime('2000-03-04T23:00:00+03:00')
+            self.assertEqual('2000-03-04T20:00:00Z', dt.xsdLiteral())
+            dt = xsd.dateTime('2000-03-04T23:00:00+03:00', _adjust_tz_=False)
+            self.assertEqual('2000-03-04T23:00:00+03:00', dt.xsdLiteral())
+            pyxb.PreserveInputTimeZone(True)
+            dt = xsd.dateTime('2000-03-04T23:00:00+03:00')
+            self.assertEqual('2000-03-04T23:00:00+03:00', dt.xsdLiteral())
+            dt = xsd.dateTime('2000-03-04T23:00:00+03:00', _adjust_tz_=True)
+            self.assertEqual('2000-03-04T20:00:00Z', dt.xsdLiteral())
+        finally:
+            pyxb.PreserveInputTimeZone(preserve)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/drivers/test-ctd-attr.py
+++ b/tests/drivers/test-ctd-attr.py
@@ -20,13 +20,15 @@ from pyxb.exceptions_ import *
 import unittest
 
 from pyxb.utils import domutils
+from pyxb.utils.testutils import XmlTestCase
+
 def ToDOM (instance):
     return instance.toDOM().documentElement
 
 def assign (lhs, rhs):
     lhs = rhs
 
-class TestCTD (unittest.TestCase):
+class TestCTD (XmlTestCase):
 
 
     # Make sure that name collisions are deconflicted in favor of the

--- a/tests/drivers/test-xsi-nil.py
+++ b/tests/drivers/test-xsi-nil.py
@@ -20,6 +20,7 @@ rv = compile(code, 'test', 'exec')
 eval(rv)
 
 from pyxb.exceptions_ import *
+from pyxb.utils.testutils import XmlTestCase
 
 import unittest
 
@@ -27,7 +28,7 @@ def setFull (instance, value):
     instance.full = value
     return instance
 
-class TestXSIType (unittest.TestCase):
+class TestXSIType (XmlTestCase):
 
     def testFull (self):
         xmlt = six.u('<full xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">content</full>')

--- a/tests/drivers/test-xsi-type.py
+++ b/tests/drivers/test-xsi-type.py
@@ -23,10 +23,11 @@ def oneFloorCtor (*args, **kw):
 originalOneFloor._SetAlternativeConstructor(oneFloorCtor)
 
 from pyxb.exceptions_ import *
+from pyxb.utils.testutils import XmlTestCase
 
 import unittest
 
-class TestXSIType (unittest.TestCase):
+class TestXSIType (XmlTestCase):
     def testFailsNoType (self):
         xmlt = six.u('<elt/>')
         doc = pyxb.utils.domutils.StringToDOM(xmlt)

--- a/tests/trac/test-issue-0007.py
+++ b/tests/trac/test-issue-0007.py
@@ -29,10 +29,11 @@ rv = compile(code, 'test', 'exec')
 eval(rv)
 
 from pyxb.exceptions_ import *
+from pyxb.utils.testutils import XmlTestCase
 
 import unittest
 
-class TestIssue0007 (unittest.TestCase):
+class TestIssue0007 (XmlTestCase):
     def testConstruction (self):
         # Absence of attribute uses implicit default
         i = number(53)

--- a/tests/trac/test-trac-0057.py
+++ b/tests/trac/test-trac-0057.py
@@ -40,10 +40,11 @@ rv = compile(code, 'test', 'exec')
 eval(rv)
 
 from pyxb.exceptions_ import *
+from pyxb.utils.testutils import XmlTestCase
 
 import unittest
 
-class TestTrac_0057 (unittest.TestCase):
+class TestTrac_0057 (XmlTestCase):
     XMLs = '<ns1:ObsProject almatype="APDM::ObsProject" revision="1.74" schemaVersion="8" xmlns:ns1="URN:test-trac-0057"><ns1:timeOfCreation>2009-05-08 21:23:45</ns1:timeOfCreation></ns1:ObsProject>'
     XMLd = XMLs.encode('utf-8')
 

--- a/tests/trac/test-trac-0058.py
+++ b/tests/trac/test-trac-0058.py
@@ -25,10 +25,11 @@ rv = compile(code, 'test', 'exec')
 eval(rv)
 
 from pyxb.exceptions_ import *
+from pyxb.utils.testutils import XmlTestCase
 
 import unittest
 
-class TestTrac_0058 (unittest.TestCase):
+class TestTrac_0058 (XmlTestCase):
     def testRoundTrip (self):
         xmlt = six.u('<iopt xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"></iopt>')
         xmld = xmlt.encode('utf-8')

--- a/tests/trac/test-trac-0069.py
+++ b/tests/trac/test-trac-0069.py
@@ -57,6 +57,7 @@ rv = compile(code, 'test', 'exec')
 eval(rv)
 
 from pyxb.exceptions_ import *
+from pyxb.utils.testutils import XmlTestCase
 
 import unittest
 import collections
@@ -72,7 +73,7 @@ value_type = value_element.typeDefinition()
 
 v_bind = pyxb.BIND('foo', lang='ENG')
 
-class TestTrac_0069 (unittest.TestCase):
+class TestTrac_0069 (XmlTestCase):
     def testMetaConstructor (self):
         newdoc = MetadataDocument()
         newdoc.template = 'anewtemplate'

--- a/tests/trac/test-trac-0071.py
+++ b/tests/trac/test-trac-0071.py
@@ -57,6 +57,7 @@ rv = compile(code, 'test', 'exec')
 eval(rv)
 
 from pyxb.exceptions_ import *
+from pyxb.utils.testutils import XmlTestCase
 
 import unittest
 import collections
@@ -72,7 +73,7 @@ value_type = value_element.typeDefinition()
 
 v_bind = pyxb.BIND('foo', lang='ENG')
 
-class TestTrac_0071 (unittest.TestCase):
+class TestTrac_0071 (XmlTestCase):
     def testFieldConstructor (self):
         field = field_type('title', pyxb.BIND('foo', lang='ENG'), _element=field_element)
         self.assertTrue(isinstance(field.value_, collections.abc.MutableSequence))

--- a/tests/trac/test-trac-0094.py
+++ b/tests/trac/test-trac-0094.py
@@ -32,6 +32,7 @@ rv = compile(code, 'test', 'exec')
 eval(rv)
 
 from pyxb.exceptions_ import *
+from pyxb.utils.testutils import XmlTestCase
 
 import unittest
 
@@ -39,7 +40,7 @@ import pyxb.utils.domutils
 import pyxb.namespace
 pyxb.utils.domutils.BindingDOMSupport.DeclareNamespace(pyxb.namespace.XMLSchema, 'xs')
 
-class TestTrac_0094 (unittest.TestCase):
+class TestTrac_0094 (XmlTestCase):
     body = 'something'
     xmlt = six.u('''<anything xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xs:string">%s</anything>''') % (body,)
     xmld = xmlt.encode('utf-8')


### PR DESCRIPTION
This PR fixes a lot of test failures, fixes a few more  (`collections` related)  Python 3.10 incompatibilities and adds `scripts/makedist`.

The `makedist` script is derived from `scripts/makedist` of the git repository at "https://git.code.sf.net/p/pyxb/releases". It prepares a new distribution ensuring that the documentation is built, the most important bundles are generated and the tests are run.