### PR TITLE
Fixes needed to run on py 3.11

### DIFF
--- a/pyxb/binding/basis.py
+++ b/pyxb/binding/basis.py
@@ -25,6 +25,11 @@ import pyxb.namespace
 from pyxb.namespace.builtin import XMLSchema_instance as XSI
 import decimal
 
+try:
+    from collections import Iterable
+except ImportError:
+    from collections.abc import Iterable
+
 _log = logging.getLogger(__name__)
 
 class _TypeBinding_mixin (utility.Locatable_mixin):
@@ -1163,7 +1168,7 @@ class simpleTypeDefinition (_TypeBinding_mixin, utility._DeconflictSymbols_mixin
             raise pyxb.SimpleTypeValueError(cls, value)
         value_class = cls
         if issubclass(cls, STD_list):
-            if not isinstance(value, collections.Iterable):
+            if not isinstance(value, Iterable):
                 raise pyxb.SimpleTypeValueError(cls, value)
             for v in value:
                 if not cls._ItemType._IsValidValue(v):
@@ -1363,7 +1368,7 @@ class STD_list (simpleTypeDefinition, six.list_type):
             if isinstance(arg1, six.string_types):
                 args = (arg1.split(),) + args[1:]
                 arg1 = args[0]
-            if isinstance(arg1, collections.Iterable):
+            if isinstance(arg1,Iterable):
                 new_arg1 = [ cls._ValidatedItem(_v, kw) for _v in arg1 ]
                 args = (new_arg1,) + args[1:]
         super_fn = getattr(super(STD_list, cls), '_ConvertArguments_vx', lambda *a,**kw: args)
@@ -1646,7 +1651,7 @@ class element (utility._DeconflictSymbols_mixin, _DynamicCreate_mixin):
             return self.__defaultValue
         is_plural = kw.pop('is_plural', False)
         if is_plural:
-            if not isinstance(value, collections.Iterable):
+            if not isinstance(value, Iterable):
                 raise pyxb.SimplePluralValueError(self.typeDefinition(), value)
             return [ self.compatibleValue(_v) for _v in value ]
         compValue = self.typeDefinition()._CompatibleValue(value, **kw);

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 import sys
 
 # The current version of the system.  Format is #.#.#[-DEV].
-version = '1.3.1'
+version = '1.3.2'
 
 # Require Python 3.10 or higher
 if (sys.version_info[:2] < (3, 10)):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 import sys
 
 # The current version of the system.  Format is #.#.#[-DEV].
-version = '1.3.0'
+version = '1.3.1'
 
 # Require Python 3.10 or higher
 if (sys.version_info[:2] < (3, 10)):


### PR DESCRIPTION
Some fixes for errors encountered while converting code using pyxb to py 3.11